### PR TITLE
Fix aggressive centering while dragging mouse

### DIFF
--- a/centered-cursor-mode.el
+++ b/centered-cursor-mode.el
@@ -222,6 +222,8 @@ This command exists, because mwheel-scroll caused strange
 behaviour with automatic recentering."
 ;;  (interactive (list last-input-event))
   (interactive "e")
+  (when (region-active-p)
+    (deactivate-mark))
   (let* ((mods (delq 'click (delq 'double (delq 'triple (event-modifiers event)))))
          (amt (assoc mods mouse-wheel-scroll-amount)))
     ;;(message "%S" mods)
@@ -307,7 +309,7 @@ the center. Just the variable ccm-vpos is set."
 
 (defun ccm-position-cursor ()
   "Do the actual recentering at the position `ccm-vpos'."
-  (unless (member this-command ccm-ignored-commands)
+  (unless (or (member this-command ccm-ignored-commands) (mouse-movement-p last-command-event))
     (unless ccm-vpos
       (ccm-vpos-recenter))
     (unless (minibufferp (current-buffer))


### PR DESCRIPTION
I just started testing out this package; awesome so far except for one issue I have noticed: When `centered-cursor-mode` is active and the mouse is clicked-and-dragged to define a region, the view will be constantly recentered, causing jumpy and extremely "amplified" scrolling.

`mouse-drag-region` is already listed in `ccm-ignored-commands`, but that doesn't seem to work for me.  (I'm running "GNU Emacs 26.0.50 (build 3, x86_64-pc-linux-gnu, GTK+ Version 3.8.8) of 2017-07-05".)  Printing the value of `this-command` while dragging the mouse results in what looks like some sort of event object: 

```
#[257 \307!\310!\211\301\242=\204\0\306\300\311\240\210\211@\262\302=\203-\0\312!\203-\0\313\301\242\305#\202Z\0\314 AA\211?\206X\0\211\303W\203H\0\315\302\303Z\316\301\242$\202X\0\211\304Y\205X\0\315\302\304ZT\316\301\242$\262\207 [(mouse-movement (#<window 3 on centered-cursor-mode.el> 13121 (457 . 1044) 15885719 nil 13121 (57 . 61) nil (1 . 7) (8 . 17))) (13121) #<window 3 on centered-cursor-mode.el> 0 77 0 t event-end posn-point mouse-movement integer-or-marker-p mouse--drag-set-mark-and-point mouse-position mouse-scroll-subr nil auto-hscroll-mode] 9 

(fn EVENT) e]
```

I don't do much with elisp outside of my own config, so I'm not sure if this patch is the correct way to handle the issue.  It seems to work for me though.  Let me know if you have any feedback.